### PR TITLE
Update confset for supporting conffile automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python: 2.7
 env:
   - TOX_ENV=py27
   - TOX_ENV=py34
+  - TOX_ENV=py35
   - TOX_ENV=pypy
 matrix:
   fast_finish: true

--- a/bin/confset
+++ b/bin/confset
@@ -3,47 +3,12 @@
 View and Set configuration file parameters
 """
 import sys
-import confset
-import optparse
-
-
-def usage():
-    """
-    Display a usage message and exit
-    :return:
-    """
-    print('confset conffile.parameter=value')
-    sys.exit(1)
-
+from confset.arguments import ConfsetArguments, create_arg_parser
 
 if __name__ == '__main__':
-    parser = optparse.OptionParser(usage='confset [setting]|[setting=value]')
-    parser.add_option('--info', default=False, action='store_true', help='Print help information for options')
+    parser = create_arg_parser()
     (options, args) = parser.parse_args()
-    args = ' '.join(args)
-    setting_filter = None
+    confset = ConfsetArguments(args, options)
 
-    if args:
-        if '.' not in args:
-            configs = confset.ConfigSettings(args)
-        else:
-            conffile = args.split('.')[0]
-            setting_filter = args.split('.')[1]
-            configs = confset.ConfigSettings(conffile)
-    else:
-        confset.print_settings(info=options.info)
-        sys.exit(0)
-
-    if '=' not in args:
-        #noinspection PyUnboundLocalVariable
-        configs.print_settings(setting_filter=setting_filter, info=options.info)
-        sys.exit(0)
-
-    if '.' not in args:
-        usage()
-
-    key = ''.join(args.split('.')[1:]).split('=')[0].strip()
-    value = '.'.join(args.split('.')[1:]).split('=')[1].strip()
-    #noinspection PyUnboundLocalVariable
-    configs.set(key, value)
+    confset.execute()
     sys.exit(0)

--- a/confset/arguments.py
+++ b/confset/arguments.py
@@ -4,6 +4,7 @@ import sys
 import confset
 import optparse
 
+
 def create_arg_parser():
     parser = optparse.OptionParser(usage='confset [setting]|[setting=value]')
     parser.add_option('--info', default=False, action='store_true', help='Print help information for options')
@@ -16,7 +17,7 @@ class ConfsetArguments(object):
         """
         Initial method for ConfsetArgument which will be called by bin/confset
         :param args: (list) List of arguments
-        :param options: (object) argument option opject 
+        :param options: (object) argument option object
         """
         self.args = self.parse_arguments(args)
         self.arg_options = options
@@ -28,25 +29,25 @@ class ConfsetArguments(object):
     def __get_confset(self):
         """
         A private method for getting the correct confset object based on the passed arguments.
-        
+
         If self.name and self.attr (e.g: `confset name.attr`):
             return confset.ConfigSettings('name.attr')
-            
+
         else if only has self.name (e.g: `confset name`):
             return confset.ConfigSettings('name')
-        
+
         else (e.g: `confset`):
             return confset
-        
+
         :return: (object) confset object
         """
-        res = confset if self.name == None else confset.ConfigSettings(self.name)
+        res = confset if self.name is None else confset.ConfigSettings(self.name)
         return res
 
     def parse_arguments(self, args=None):
         """
         Parse the confset arguments which provided by user and verify it
-        
+
         **Valid arguments**
             ```
             $ confset
@@ -56,7 +57,7 @@ class ConfsetArguments(object):
             $ confset name.attr="value with space"
             $ confset name.attr=value_without_space
             ```
-            
+
         **Invalid arguments**
             ```
             $ confset .name
@@ -67,14 +68,14 @@ class ConfsetArguments(object):
             $ confset name.attr=value name.attr1=value
             $ confset name.attr=value; name.attr1=value
             ```
-        
+
         :param args: (list) List of arguments
         :return: (dict) Parsed argument with dictionary type, e.g:
             ```
             {
                 'namespace': <str | None>,
                 'attribute': <str | None>,
-                'value': <str | None>,   
+                'value': <str | None>,
             }
             ```
         """
@@ -82,7 +83,7 @@ class ConfsetArguments(object):
         rgx_p = r'^(?P<namespace>[a-zA-Z0-9\-\_]+)(\.(?P<attribute>[a-zA-Z0-9\-\_]+))?(=(?P<value>.*))?$'
         rgx_m = re.match(rgx_p, args)
         res = rgx_m.groupdict() if rgx_m else {'namespace': None, 'attribute': None, 'value': None}
-        if (args and not rgx_m) or (res['value'] != None and (not res['namespace'] or not res['attribute'])):
+        if (args and not rgx_m) or (res['value'] is None and (not res['namespace'] or not res['attribute'])):
             print(
                 'Incorrect command. The proper confset command should be:',
                 '  $ confset name.attr=value',
@@ -95,7 +96,7 @@ class ConfsetArguments(object):
         """
         Get conf filter based on the conf name and attribute
         :return: (str)
-        
+
             if user provides conf name and attribute:
                 filter = 'name.attribute'
             else:
@@ -106,10 +107,10 @@ class ConfsetArguments(object):
 
     def execute(self):
         """
-        Execute the actual confset command based on the args. 
+        Execute the actual confset command based on the args.
         :return: N/A
         """
-        if self.name and self.attr and self.value != None:
+        if self.name and self.attr and self.value is not None:
             self.confset.set(self.attr, self.value)
 
         self.confset.print_settings(

--- a/confset/arguments.py
+++ b/confset/arguments.py
@@ -99,14 +99,14 @@ class ConfsetArguments(object):
         
             | verified | namespace | attribute | value |
             |----------|-----------|-----------|-------|
-            |   True   |     ●     |     ●     |   ●   |
-            |   True   |     ●     |     ●     |   -   |
-            |   True   |     ●     |     -     |   -   |
+            |   True   |     Y     |     Y     |   Y   |
+            |   True   |     Y     |     Y     |   -   |
+            |   True   |     Y     |     -     |   -   |
             |   True   |     -     |     -     |   -   |
-            |   False  |     -     |     ●     |   -   |
-            |   False  |     -     |     -     |   ●   |
-            |   False  |     -     |     ●     |   ●   |
-            |   False  |     ●     |     -     |   ●   |
+            |   False  |     -     |     Y     |   -   |
+            |   False  |     -     |     -     |   Y   |
+            |   False  |     -     |     Y     |   Y   |
+            |   False  |     Y     |     -     |   Y   |
             
         :param data: (dict) Parsed arguments, e.g:
             {

--- a/confset/arguments.py
+++ b/confset/arguments.py
@@ -1,0 +1,118 @@
+from __future__ import print_function
+import re
+import sys
+import confset
+import optparse
+
+def create_arg_parser():
+    parser = optparse.OptionParser(usage='confset [setting]|[setting=value]')
+    parser.add_option('--info', default=False, action='store_true', help='Print help information for options')
+    return parser
+
+
+class ConfsetArguments(object):
+
+    def __init__(self, args=None, options=None):
+        """
+        Initial method for ConfsetArgument which will be called by bin/confset
+        :param args: (list) List of arguments
+        :param options: (object) argument option opject 
+        """
+        self.args = self.parse_arguments(args)
+        self.arg_options = options
+        self.name = self.args['namespace']
+        self.attr = self.args['attribute']
+        self.value = self.args['value']
+        self.confset = self.__get_confset()
+
+    def __get_confset(self):
+        """
+        A private method for getting the correct confset object based on the passed arguments.
+        
+        If self.name and self.attr (e.g: `confset name.attr`):
+            return confset.ConfigSettings('name.attr')
+            
+        else if only has self.name (e.g: `confset name`):
+            return confset.ConfigSettings('name')
+        
+        else (e.g: `confset`):
+            return confset
+        
+        :return: (object) confset object
+        """
+        res = confset if self.name == None else confset.ConfigSettings(self.name)
+        return res
+
+    def parse_arguments(self, args=None):
+        """
+        Parse the confset arguments which provided by user and verify it
+        
+        **Valid arguments**
+            ```
+            $ confset
+            $ confset name
+            $ confset name.attr
+            $ confset name.attr=value
+            $ confset name.attr="value with space"
+            $ confset name.attr=value_without_space
+            ```
+            
+        **Invalid arguments**
+            ```
+            $ confset .name
+            $ confset name=value
+            $ confset name = value
+            $ confset =value
+            $ confset name.attr=value with space
+            $ confset name.attr=value name.attr1=value
+            $ confset name.attr=value; name.attr1=value
+            ```
+        
+        :param args: (list) List of arguments
+        :return: (dict) Parsed argument with dictionary type, e.g:
+            ```
+            {
+                'namespace': <str | None>,
+                'attribute': <str | None>,
+                'value': <str | None>,   
+            }
+            ```
+        """
+        args = ' '.join(args).strip()
+        rgx_p = r'^(?P<namespace>[a-zA-Z0-9\-\_]+)(\.(?P<attribute>[a-zA-Z0-9\-\_]+))?(=(?P<value>.*))?$'
+        rgx_m = re.match(rgx_p, args)
+        res = rgx_m.groupdict() if rgx_m else {'namespace': None, 'attribute': None, 'value': None}
+        if (args and not rgx_m) or (res['value'] != None and (not res['namespace'] or not res['attribute'])):
+            print(
+                'Incorrect command. The proper confset command should be:',
+                '  $ confset name.attr=value',
+                sep='\n'
+            )
+            sys.exit(1)
+        return res
+
+    def get_filters(self):
+        """
+        Get conf filter based on the conf name and attribute
+        :return: (str)
+        
+            if user provides conf name and attribute:
+                filter = 'name.attribute'
+            else:
+                filter = ''
+        """
+        res = '%s.%s' % (self.name, self.attr) if self.name and self.attr else ''
+        return res
+
+    def execute(self):
+        """
+        Execute the actual confset command based on the args. 
+        :return: N/A
+        """
+        if self.name and self.attr and self.value != None:
+            self.confset.set(self.attr, self.value)
+
+        self.confset.print_settings(
+            setting_filter=self.get_filters(),
+            info=self.arg_options.info
+        )

--- a/confset/arguments.py
+++ b/confset/arguments.py
@@ -99,14 +99,14 @@ class ConfsetArguments(object):
         
             | verified | namespace | attribute | value |
             |----------|-----------|-----------|-------|
-            |   True   |     √     |     √     |   √   |
-            |   True   |     √     |     √     |   -   |
-            |   True   |     √     |     -     |   -   |
+            |   True   |     ●     |     ●     |   ●   |
+            |   True   |     ●     |     ●     |   -   |
+            |   True   |     ●     |     -     |   -   |
             |   True   |     -     |     -     |   -   |
-            |   False  |     -     |     √     |   -   |
-            |   False  |     -     |     -     |   √   |
-            |   False  |     -     |     √     |   √   |
-            |   False  |     √     |     -     |   √   |
+            |   False  |     -     |     ●     |   -   |
+            |   False  |     -     |     -     |   ●   |
+            |   False  |     -     |     ●     |   ●   |
+            |   False  |     ●     |     -     |   ●   |
             
         :param data: (dict) Parsed arguments, e.g:
             {

--- a/confset/confset.py
+++ b/confset/confset.py
@@ -52,15 +52,15 @@ class ConfigSettings(object):
 
     def empty_conf_file(self):
         """
-        Return a fully filename
-        :return:
+        Return a fully filename. If conffile does not exist, it will create a conffile automatically
+        :return: (str) conf file full path
         """
         for d in self.confpath:
             if os.path.isdir(d) and os.access(d, os.W_OK):
                 return os.path.join(d, self.conffile)
-        raise ConfsetException(
-            'Unable to find a writable configuration directory'
-        )   # pragma: no cover
+        # create conf file if not exist
+        with open(os.path.join(self.confpath[-1], self.conffile), 'w+') as f:
+            return os.path.join(self.confpath[-1], self.conffile)
 
     def available_settings(self):
         """

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -234,7 +234,7 @@ class TestConfsetArguments(unittest.TestCase):
     def test_invalid_arguments(self):
         """
         Test all invalid commands. Any command from here should all raise sys.exit(1)
-        :return: 
+        :return:
         """
         cmd = '.test_attr'
         with self.assertRaises(SystemExit) as cm:
@@ -288,26 +288,10 @@ class TestConfsetArguments(unittest.TestCase):
 
         self.assertEqual(cm.exception.code, 1)
 
-        '''
-        cmd = 'test_name.test_attr=test value missing quotes'
-        with self.assertRaises(SystemExit) as cm:
-            (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
-
-        self.assertEqual(cm.exception.code, 1)
-
-        cmd = 'test_name.test_attr="test value missing invalid quotes\''
-        with self.assertRaises(SystemExit) as cm:
-            (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
-
-        self.assertEqual(cm.exception.code, 1)
-        '''
-
         cmd = 'test_name.test_attr test_name1.test_attr1'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         self.assertEqual(cm.exception.code, 1)
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -239,52 +239,52 @@ class TestConfsetArguments(unittest.TestCase):
         cmd = '.test_attr'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         self.assertEqual(cm.exception.code, 1)
 
         cmd = '.test_attr=test_value'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         self.assertEqual(cm.exception.code, 1)
 
         cmd = '=test_value'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         self.assertEqual(cm.exception.code, 1)
 
         cmd = 'test_name=test_value'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         self.assertEqual(cm.exception.code, 1)
 
         cmd = 'test_name.name.attr=test_value'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         self.assertEqual(cm.exception.code, 1)
 
         cmd = 'test name.test_attr=test_value'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         cmd = 'test%name.test_attr=test_value'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         cmd = 'test_name.test_attr = test_value'
         with self.assertRaises(SystemExit) as cm:
             (options, args) = self.parser.parse_args(cmd.split(' '))
-            _ = ConfsetArguments(args, options)
+            ConfsetArguments(args, options)
 
         self.assertEqual(cm.exception.code, 1)
 

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,0 +1,317 @@
+import logging
+import os
+import confset
+import shutil
+import tempfile
+import unittest
+from confset.arguments import ConfsetArguments, create_arg_parser
+try:
+    from unittest import mock
+except:
+    import mock
+
+
+# noinspection PyPep8Naming
+class TestConfsetArguments(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = create_arg_parser()
+        self.tempdir = tempfile.mkdtemp()
+        self.config_file = 'testarg'
+        self.config_file_full = os.path.join(self.tempdir, self.config_file)
+        confset.CONF_PATH.append(self.tempdir)
+
+    def tearDown(self):
+        if os.path.exists(self.tempdir):
+            shutil.rmtree(self.tempdir)
+        confset.CONF_PATH.remove(self.tempdir)
+        self.tempdir = None
+
+    @mock.patch('confset.confset.ConfigSettings.print_settings')
+    def test_get_conf_without_arguments(self, mock_print):
+        cmd = ''
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertIsNone(test_instance.name)
+        self.assertIsNone(test_instance.attr)
+        self.assertIsNone(test_instance.value)
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), '')
+        test_instance.execute()
+        self.assertTrue(mock_print.called)
+
+        cmd = '--info'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertIsNone(test_instance.name)
+        self.assertIsNone(test_instance.attr)
+        self.assertIsNone(test_instance.value)
+        self.assertTrue(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), '')
+        test_instance.execute()
+        self.assertTrue(mock_print.called)
+
+    @mock.patch('confset.confset.ConfigSettings.print_settings')
+    def test_get_conf_with_name(self, mock_print):
+        cmd = 'test_name'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertIsNone(test_instance.attr)
+        self.assertIsNone(test_instance.value)
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), '')
+        test_instance.execute()
+        mock_print.assert_called_with(setting_filter='', info=False)
+
+        cmd = 'test_name12345'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name12345')
+        self.assertIsNone(test_instance.attr)
+        self.assertIsNone(test_instance.value)
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), '')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_print.assert_called_with(setting_filter='', info=False)
+
+        cmd = 'test_name --info'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertIsNone(test_instance.attr)
+        self.assertIsNone(test_instance.value)
+        self.assertTrue(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), '')
+        test_instance.execute()
+        mock_print.assert_called_with(setting_filter='', info=True)
+
+    @mock.patch('confset.confset.ConfigSettings.print_settings')
+    def test_get_conf_with_name_attr(self, mock_print):
+        cmd = 'test_name.test_attr'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'test_attr')
+        self.assertIsNone(test_instance.value)
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.test_attr')
+        test_instance.execute()
+        mock_print.assert_called_with(setting_filter='test_name.test_attr', info=False)
+
+        cmd = 'test_name.test_attr_12345'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'test_attr_12345')
+        self.assertIsNone(test_instance.value)
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.test_attr_12345')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_print.assert_called_with(setting_filter='test_name.test_attr_12345', info=False)
+
+        cmd = 'test_name._test_attr'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, '_test_attr')
+        self.assertIsNone(test_instance.value)
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name._test_attr')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_print.assert_called_with(setting_filter='test_name._test_attr', info=False)
+
+        cmd = 'test_name.TEST_ATTR'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'TEST_ATTR')
+        self.assertIsNone(test_instance.value)
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.TEST_ATTR')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_print.assert_called_with(setting_filter='test_name.TEST_ATTR', info=False)
+
+        cmd = 'test_name.TEST_ATTR --info'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'TEST_ATTR')
+        self.assertIsNone(test_instance.value)
+        self.assertTrue(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.TEST_ATTR')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_print.assert_called_with(setting_filter='test_name.TEST_ATTR', info=True)
+
+    @mock.patch('confset.confset.ConfigSettings.set')
+    @mock.patch('confset.confset.ConfigSettings.print_settings')
+    def test_set_key(self, mock_print, mock_set):
+        cmd = 'test_name.test_attr=test_value'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'test_attr')
+        self.assertEqual(test_instance.value, 'test_value')
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.test_attr')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_set.assert_called_with('test_attr', 'test_value')
+        mock_print.assert_called_with(setting_filter='test_name.test_attr', info=False)
+
+        cmd = 'test_name.test_attr="test value with space"'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'test_attr')
+        self.assertEqual(test_instance.value, '"test value with space"')
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.test_attr')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_set.assert_called_with('test_attr', '"test value with space"')
+        mock_print.assert_called_with(setting_filter='test_name.test_attr', info=False)
+
+        cmd = 'test_name.test_attr=\'test value with space and single quote\''
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'test_attr')
+        self.assertEqual(test_instance.value, '\'test value with space and single quote\'')
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.test_attr')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_set.assert_called_with('test_attr', '\'test value with space and single quote\'')
+        mock_print.assert_called_with(setting_filter='test_name.test_attr', info=False)
+
+        cmd = 'test_name.test_attr="test value with space and number 13454.2314"'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'test_attr')
+        self.assertEqual(test_instance.value, '"test value with space and number 13454.2314"')
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.test_attr')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_set.assert_called_with('test_attr', '"test value with space and number 13454.2314"')
+        mock_print.assert_called_with(setting_filter='test_name.test_attr', info=False)
+
+        cmd = 'test_name.test_attr="special characters %#$&%#!%"'
+        (options, args) = self.parser.parse_args(cmd.split(' '))
+        test_instance = ConfsetArguments(args, options)
+
+        self.assertEqual(test_instance.name, 'test_name')
+        self.assertEqual(test_instance.attr, 'test_attr')
+        self.assertEqual(test_instance.value, '"special characters %#$&%#!%"')
+        self.assertFalse(test_instance.arg_options.info)
+        self.assertEqual(test_instance.get_filters(), 'test_name.test_attr')
+        self.assertIsNone(test_instance.execute())
+        test_instance.execute()
+        mock_set.assert_called_with('test_attr', '"special characters %#$&%#!%"')
+        mock_print.assert_called_with(setting_filter='test_name.test_attr', info=False)
+
+    def test_invalid_arguments(self):
+        """
+        Test all invalid commands. Any command from here should all raise sys.exit(1)
+        :return: 
+        """
+        cmd = '.test_attr'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+
+        cmd = '.test_attr=test_value'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+
+        cmd = '=test_value'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+
+        cmd = 'test_name=test_value'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+
+        cmd = 'test_name.name.attr=test_value'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+
+        cmd = 'test name.test_attr=test_value'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        cmd = 'test%name.test_attr=test_value'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        cmd = 'test_name.test_attr = test_value'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+
+        '''
+        cmd = 'test_name.test_attr=test value missing quotes'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+
+        cmd = 'test_name.test_attr="test value missing invalid quotes\''
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+        '''
+
+        cmd = 'test_name.test_attr test_name1.test_attr1'
+        with self.assertRaises(SystemExit) as cm:
+            (options, args) = self.parser.parse_args(cmd.split(' '))
+            _ = ConfsetArguments(args, options)
+
+        self.assertEqual(cm.exception.code, 1)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,14 @@ skip_missing_interpreters=True
 
 # Removed pypy3 due to issues with the psutil dependency on that python
 # version.
-envlist = py27,py34,pypy,pypy3
+envlist = py27,py34,py35,pypy,pypy3
 
 [testenv]
 deps=
     nose
     nose-cov
     coveralls
+    mock
 
 commands=
     nosetests --exe --with-xunit --xunit-file=nosetests.xml --with-coverage --cover-xml --cover-erase  --cover-package=confset --cover-xml-file=cobertura.xml tests


### PR DESCRIPTION
Pending by unit test. Will request a proper code review after PR build passed.

1. Create conffile automatically when conffile doesn't exist
1. Move the major part of bin/confset to confset/arguments.py
1. Unit test for arguments
1. Add py35 in tox.ini to make sure confset can support python3.5 as well